### PR TITLE
DVL-9884: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in `weed`, please report
+it to us privately. **Do not open a public GitHub issue, pull request, or discussion
+for security reports.**
+
+Email **security@apono.io** with the details. Where possible, please include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof of concept.
+- The affected version, commit, or configuration.
+- Any suggested remediation, if you have one.
+
+We will work with you to understand and resolve the issue. We ask that you give us a
+reasonable opportunity to investigate and release a fix before any public disclosure,
+and that you avoid accessing or modifying data that is not your own while researching.
+
+## Supported Versions
+
+Security fixes are applied to the latest released version of `weed`. We recommend
+always running the most recent release.
+
+## Disclosure
+
+We follow a coordinated disclosure process and will credit reporters who wish to be
+acknowledged once a fix is available.


### PR DESCRIPTION
Adds a Security Policy directing vulnerability reports to security@apono.io. Resolves the OX "Security Policy file missing" finding for this repository.